### PR TITLE
silence popd output

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -23,7 +23,7 @@ BOOTSTRAP_COMMAND="cd "${APNSCP_HOME}/resources/playbooks" && env ANSIBLE_LOG_PA
 function fatal {
   echo -e "${RED}${BOLD}ERR:${EMODE} $1"
   echo -e "${RED}Installation failed${EMODE}"
-  popd > /dev/null
+  popd > /dev/null 2>&1
   exit 1
 }
 


### PR DESCRIPTION
```text
# curl https://raw.githubusercontent.com/apisnetworks/apnscp-bootstrapper/master/bootstrap.sh | bash -s - <key>
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  4129  100  4129    0     0  30575      0 --:--:-- --:--:-- --:--:-- 30813
ERR: Invalid activation key. Must be 32 characters long. Visit https://my.apnscp.com
Installation failed
bash: line 26: popd: directory stack empty
```
can popd be silenced?

https://github.com/apisnetworks/apnscp-bootstrapper/blob/c9cb58fdd0298ed1173268c0bfaed42ee82af5cd/bootstrap.sh#L26

```
popd > /dev/null 2>&1
```